### PR TITLE
chore: add control info; fix: generation time

### DIFF
--- a/accuknox-kubescape-job/templates/configmap.yaml
+++ b/accuknox-kubescape-job/templates/configmap.yaml
@@ -7,14 +7,27 @@ data:
   augment-and-push-results.sh: |
     #! /bin/env bash
 
+    # get all controls
+    jq -s 'map(.controls[]) | unique_by(.controlID) | .[]' /data/kubescape-cache/allcontrols.json \
+      /data/kubescape-cache/clusterscan.json \
+      /data/kubescape-cache/mitre.json /data/kubescape-cache/nsa.json > /data/controllist.json
+
+    export GENERATION_TIME=`date --utc --iso-8601=s`
+
+    # augment result
     cat <<< $(jq ". +=
       {
+        "generationTime": "'$ENV.GENERATION_TIME'",
+        "summary": {
+          "controls": "'$controllist'"
+        },
         "accuknox_metadata": {
-          "cluster_name":"'$ENV.CLUSTER_NAME'",
-          "label_name":"'$ENV.LABEL_NAME'"
+          "cluster_name": "'$ENV.CLUSTER_NAME'",
+          "label_name": "'$ENV.LABEL_NAME'"
         }
-      }" /data/report.json) > /data/report.json
+      }" /data/report.json --slurpfile controllist /data/controllist.json) > /data/report.json
 
+    # push
     curl --location --request POST \
     --header "Authorization: Bearer ${AUTH_TOKEN}" \
     --header "Tenant-Id: ${TENANT_ID}" \

--- a/accuknox-kubescape-job/templates/cronjob.yaml
+++ b/accuknox-kubescape-job/templates/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
           initContainers:
             - name: kubescape-init
               image: "{{ .Values.kubescape.image.repository }}:{{ if ne .Values.kubescape.image.tag "" }}{{ .Values.kubescape.image.tag }}{{ else }}v{{ .Chart.AppVersion }}{{ end }}"
-              args: ["scan", "--format", "json", "--output", "/data/report.json", "--cluster-name=$(CLUSTER_NAME)"]
+              args: ["scan", "framework", "allcontrols,clusterscan,mitre,nsa", "--format", "json", "--cache-dir", "/data/kubescape-cache", "--output", "/data/report.json", "--cluster-name=$(CLUSTER_NAME)"]
               env:
                 - name: CLUSTER_NAME
                   value: {{ if ne .Values.accuknox.clusterName "" }}{{ .Values.accuknox.clusterName }}{{ else }}{{ "default" }}{{ end }}


### PR DESCRIPTION
### Description
- Adds control list from kubescape cache - ensures that only those controls which were actually run are added to the JSON
- Adds correct generationTime

<details>

```json
	... kubescape raw result
	"summary": {
		"controls": [
			{
				"rulesIDs": [
					""
				],
				"guid": "",
				"name": "Prevent containers from allowing command execution",
				"attributes": {
					"microsoftMitreColumns": [
						"Execution"
					],
					"rbacQuery": "Show who can access into pods",
					"controlTypeTags": [
						"compliance",
						"security-impact"
					]
				},
				"controlID": "C-0002",
				"creationTime": "",
				"description": "Attackers with relevant permissions can run malicious commands in the context of legitimate containers in the cluster using "kubectl exec" command. This control determines which subjects have permissions to use this command.",
				"remediation": "It is recommended to prohibit "kubectl exec" command in production environments. It is also recommended not to use subjects with this permission for daily cluster operations.",
				"rules": [
					{
						"guid": "",
						"name": "exec-into-container-v1",
						"attributes": {
							"m$K8sThreatMatrix": "Privilege Escalation::Exec into container",
							"resourcesAggregator": "subject-role-rolebinding",
							"useFromKubescapeVersion": "v1.0.133"
						},
						"creationTime": "",
						"rule": "package armo_builtins\n\nimport future.keywords.in\n\n# input: regoResponseVectorObject\n# returns subjects that can exec into container\n\ndeny[msga] {\n\tsubjectVector := input[_]\n\trole := subjectVector.relatedObjects[i]\n\trolebinding := subjectVector.relatedObjects[j]\n\tendswith(role.kind, \"Role\")\n\tendswith(rolebinding.kind, \"Binding\")\n\n\trule := role.rules[p]\n\n\tsubject := rolebinding.subjects[k]\n\tis_same_subjects(subjectVector, subject)\n\n\trule_path := sprintf(\"relatedObjects[%d].rules[%d]\", [i, p])\n\n\tverbs := [\"create\", \"*\"]\n\tverb_path := [sprintf(\"%s.verbs[%d]\", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]\n\tcount(verb_path) > 0\n\n\tapi_groups := [\"\", \"*\"]\n\tapi_groups_path := [sprintf(\"%s.apiGroups[%d]\", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]\n\tcount(api_groups_path) > 0\n\n\tresources := [\"pods/exec\", \"pods/*\", \"*\"]\n\tresources_path := [sprintf(\"%s.resources[%d]\", [rule_path, l]) | resource = rule.resources[l]; resource in resources]\n\tcount(resources_path) > 0\n\n\tpath := array.concat(resources_path, verb_path)\n\tpath2 := array.concat(path, api_groups_path)\n\tfinalpath := array.concat(path2, [\n\t\tsprintf(\"relatedObjects[%d].subjects[%d]\", [j, k]),\n\t\tsprintf(\"relatedObjects[%d].roleRef.name\", [j]),\n\t])\n\n\tmsga := {\n\t\t\"alertMessage\": sprintf(\"Subject: %s-%s can exec into containers\", [subjectVector.kind, subjectVector.name]),\n\t\t\"alertScore\": 9,\n\t\t\"packagename\": \"armo_builtins\",\n\t\t\"reviewPaths\": finalpath,\n\t\t\"failedPaths\": finalpath,\n\t\t\"fixPaths\": [],\n\t\t\"alertObject\": {\n\t\t\t\"k8sApiObjects\": [],\n\t\t\t\"externalObjects\": subjectVector,\n\t\t},\n\t}\n}\n\n# for service accounts\nis_same_subjects(subjectVector, subject) {\n\tsubjectVector.kind == subject.kind\n\tsubjectVector.name == subject.name\n\tsubjectVector.namespace == subject.namespace\n}\n\n# for users/ groups\nis_same_subjects(subjectVector, subject) {\n\tsubjectVector.kind == subject.kind\n\tsubjectVector.name == subject.name\n\tsubjectVector.apiGroup == subject.apiGroup\n}\n",
						"resourceEnumerator": "",
						"ruleLanguage": "Rego",
						"match": [
							{
								"apiGroups": [
									"rbac.authorization.k8s.io"
								],
								"apiVersions": [
									"v1"
								],
								"resources": [
									"RoleBinding",
									"ClusterRoleBinding",
									"Role",
									"ClusterRole"
								]
							}
						],
						"ruleDependencies": [],
						"controlConfigInputs": null,
						"description": "determines which users have permissions to exec into pods",
						"remediation": "",
						"ruleQuery": "armo_builtins",
						"relevantCloudProviders": null
					}
				],
				"baseScore": 5,
				"scanningScope": {
					"matches": [
						"cluster",
						"file"
					]
				},
				"category": {
					"name": "Access control",
					"id": "Cat-2"
				}
			},
            
            ...... so on for each control
      ]
    },
    "accuknox_metadata": {
		"cluster_name": "default",
		"label_name": "default"
	}

```

</details>