### PR TITLE
Making label mandatory param | Updated cis-job.yaml

### DIFF
--- a/cis-k8s-job/templates/cis-job.yaml
+++ b/cis-k8s-job/templates/cis-job.yaml
@@ -13,7 +13,7 @@ spec:
           containers:
           - image: accuknox/accuknox-job:latest
             command: ["/bin/sh", "-c"]
-            args: ['/bin/sh entrypoint.sh && curl --location --request POST "https://${URL}/api/v1/artifact/?tenant_id=${TENANT_ID}&data_type=KB&save_to_s3=true" --header "Tenant-Id: ${TENANT_ID}" --header "Authorization: Bearer ${AUTH_TOKEN}" --form "file=@\"./data/report.json\"" && cat /data/report.json']
+            args: ['/bin/sh entrypoint.sh && curl --location --request POST "https://${URL}/api/v1/artifact/?tenant_id=${TENANT_ID}&data_type=KB&label_id=${LABEL_NAME}&save_to_s3=true" --header "Tenant-Id: ${TENANT_ID}" --header "Authorization: Bearer ${AUTH_TOKEN}" --form "file=@\"./data/report.json\"" && cat /data/report.json']
             name: cis-k8s-cronjob
             resources: {}
             env:


### PR DESCRIPTION
Since label is mandatory parameter now or else you will get this error `{"label_id":["This field is required."]}`