### PR TITLE
added support for sonarcloud.io

### DIFF
--- a/sast-job/README.md
+++ b/sast-job/README.md
@@ -6,6 +6,7 @@ docker run --rm -it \
 	-e SQ_URL=http://35.188.10.229:9000 \
 	-e SQ_AUTH_TOKEN=<AUTH-TOKEN> \
 	-e SQ_PROJECTS="^nimbus$" \
+	-e SQ_ORG="accuknox" /* needed for sonarcloud.io */ \
 	-e REPORT_PATH=/app/data/ \
 	-v $PWD:/app/data/ \
 	accuknox/sastjob:latest
@@ -17,9 +18,10 @@ This will create a bunch of SQ-*.json files, one for every project/component fou
 
 |      Var       | Sample Value              | Description                        |
 |----------------|---------------------------|------------------------------------|
-| SQ_URL*        | http://35.188.10.229:9000 | SonarQube server URL               |
+| SQ_URL*        | http://35.188.10.229:9000, https://sonarcloud.io/ | SonarQube server URL               |
 | SQ_AUTH_TOKEN* | squ_token                 | SonarQube user authn token         |
 | SQ_PROJECTS    | "^nimbus$"                | Scan the given projects/components |
+| SQ_ORG    | "accuknox"                | Required in case of sonarcloud enterprise. |
 | REPORT_PATH    | /app/data/                | Path to keep the report json files |
 
 > variables marked with '*' are mandatory configuration options

--- a/sast-job/sq-job.py
+++ b/sast-job/sq-job.py
@@ -264,6 +264,9 @@ def _build_issues_string(issues, auth_token, results, sonar_url, hotspots=False)
         else:
             rule = issue["rule"]
             params = {"key": rule}
+            if sq_org != "":
+                params["organization"] = sq_org
+
             success = False
             while not success:
                 try:
@@ -389,6 +392,8 @@ def get_all_results(
     api = urllib.parse.urljoin(sonar_url, "api/components/search")
 
     params = {"qualifiers": "TRK", "ps": 500, "p": 1}
+    if sq_org != "":
+        params["organization"] = sq_org
 
     log.info("sonarqube: initiating components search ...")
     try:
@@ -638,9 +643,11 @@ if __name__ == '__main__':
     sq_url = os.environ.get("SQ_URL", "")
     sq_auth_token = os.environ.get('SQ_AUTH_TOKEN', "")
     sq_projects = os.environ.get('SQ_PROJECTS', ".*")
+    sq_org = os.environ.get('SQ_ORG', "")
     SCANNED_FILE_DIR = os.environ.get('REPORT_PATH', "./")
     
     if sq_url == "" or sq_auth_token == "":
         log.error("SQ_URL or SQ_AUTH_TOKEN env var not specified")
         exit(1)
+    log.info(f"SQ_ORG={sq_org}")
     get_all_results(sq_auth_token, sq_url)


### PR DESCRIPTION
sonarcloud.io or SonarQube enterprise requires organization parameter to be explicitly passed to the APIs. The updated code optionally takes SQ_ORG as the env var and uses it if available.