### PR TITLE
feat(k8s-risk-assessment): support for airgapped environments

### DIFF
--- a/k8s-risk-assessment-job/.helmignore
+++ b/k8s-risk-assessment-job/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+Dockerfile

--- a/k8s-risk-assessment-job/Dockerfile
+++ b/k8s-risk-assessment-job/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.22.0 AS downloader
+RUN apk add --no-cache ca-certificates curl
+ENV KUBESCAPE_VERSION=v3.0.8
+ARG ARCH=""
+RUN curl \
+    -L "https://github.com/kubescape/kubescape/releases/download/${KUBESCAPE_VERSION}/kubescape${ARCH}-ubuntu-latest" \
+    -o /usr/local/bin/kubescape
+RUN chmod +x /usr/local/bin/kubescape
+
+FROM alpine:3.22.0 AS runner
+RUN apk add --no-cache ca-certificates
+COPY --from=downloader /usr/local/bin/kubescape /usr/local/bin/kubescape
+RUN mkdir -p /opt/kubescape/artifacts && \
+    kubescape download artifacts --output /opt/kubescape/artifacts && \
+    kubescape download framework clusterscan --output /opt/kubescape/artifacts/clusterscan.json
+RUN adduser --disabled-password --no-create-home kubescape
+RUN mkdir -p /data && chown kubescape:kubescape /data
+USER kubescape
+ENTRYPOINT ["/usr/local/bin/kubescape"]

--- a/k8s-risk-assessment-job/templates/cronjob.yaml
+++ b/k8s-risk-assessment-job/templates/cronjob.yaml
@@ -22,7 +22,21 @@ spec:
           initContainers:
             - name: job-init-container
               image: "{{ include "kubescape.image" . }}"
-              args: ["scan", "framework", "allcontrols,clusterscan,mitre,nsa", "--format", "json", "--cache-dir", "/data/kubescape-cache", "--output", "/data/report.json", "--cluster-name=$(CLUSTER_NAME)"]
+              args:
+                - scan
+                - framework
+                - allcontrols,clusterscan,mitre,nsa
+                - --format
+                - json
+                - --cache-dir
+                - /data/kubescape-cache
+                - --output
+                - /data/report.json
+                - --cluster-name=$(CLUSTER_NAME)
+                {{- if .Values.airgapped }}
+                - --use-artifacts-from
+                - /opt/kubescape/artifacts
+                {{- end }}
               env:
                 - name: CLUSTER_NAME
                   value: {{ .Values.clusterName }}

--- a/k8s-risk-assessment-job/templates/job.yaml
+++ b/k8s-risk-assessment-job/templates/job.yaml
@@ -18,7 +18,21 @@ spec:
       initContainers:
         - name: job-init-container
           image: "{{ include "kubescape.image" . }}"
-          args: ["scan", "framework", "allcontrols,clusterscan,mitre,nsa", "--format", "json", "--cache-dir", "/data/kubescape-cache", "--output", "/data/report.json", "--cluster-name=$(CLUSTER_NAME)"]
+          args:
+            - scan
+            - framework
+            - allcontrols,clusterscan,mitre,nsa
+            - --format
+            - json
+            - --cache-dir
+            - /data/kubescape-cache
+            - --output
+            - /data/report.json
+            - --cluster-name=$(CLUSTER_NAME)
+            {{- if .Values.airgapped }}
+            - --use-artifacts-from
+            - /opt/kubescape/artifacts
+            {{- end }}
           env:
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName }}

--- a/k8s-risk-assessment-job/values.yaml
+++ b/k8s-risk-assessment-job/values.yaml
@@ -32,3 +32,4 @@ clusterName: ""
 clusterID: 0
 label: ""
 secretName: ""
+airgapped: false


### PR DESCRIPTION
- Builds a wrapper image around the official `kubescape` cli image that pre-downloads all the required artifacts.
- Helm charts now support an additional flag `--set airgapped=true`, which when set will force the k8s-risk-assessment's init container to use the pre-downloaded artifacts.

Here's the wrapper image that wraps kubescape v3.0.8: `public.ecr.aws/k9v9d5v2/k8s-risk-assessment:v3.0.8`