### PR TITLE
CNAPP-22306 ME env | Investigate and fix cluster name inconsistency issue

### DIFF
--- a/kspm-jobs/cis-k8s-job/config/app.yaml
+++ b/kspm-jobs/cis-k8s-job/config/app.yaml
@@ -4,7 +4,7 @@ jobs:
   {{- end }}
   url: https://{{ include "global.jobURL" .  }}/api/v1/artifact/?tenant_id={{ .Values.global.tenantId }}&data_type=KB&label_id={{ .Values.global.label }}&save_to_s3=true
   tenantID: {{ .Values.global.tenantId }}
-  clusterName: {{ .Values.global.clusterName }}
+  clusterName: "{{ .Values.global.clusterName }}"
   labelName: {{ .Values.global.label }}
   dataType: "KB"
   saveToS3: true

--- a/kspm-jobs/k8s-risk-assessment-job/config/app.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/config/app.yaml
@@ -4,7 +4,7 @@ jobs:
   {{- end }}
   url: https://{{ include "global.jobURL" . }}/api/v1/artifact/?tenant_id={{ .Values.global.tenantId }}&data_type=KS&label_id={{ .Values.global.label }}&save_to_s3=true
   tenantID: {{ .Values.global.tenantId }}
-  clusterName: {{ .Values.global.clusterName }}
+  clusterName: "{{ .Values.global.clusterName }}"
   labelName: {{ .Values.global.label }}
   dataType: "KS"
   saveToS3: true

--- a/kspm-jobs/k8s-risk-assessment-job/templates/cronjob.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
                 {{- end }}
               env:
                 - name: CLUSTER_NAME
-                  value: {{ .Values.global.clusterName }}
+                  value: "{{ .Values.global.clusterName }}"
               volumeMounts:
                 - name: datapath
                   mountPath: /data

--- a/kspm-jobs/k8s-risk-assessment-job/templates/job.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/job.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
           env:
             - name: CLUSTER_NAME
-              value: {{ .Values.clusterName }}
+              value: "{{ .Values.global.clusterName }}"
           volumeMounts:
             - name: datapath
               mountPath: /data

--- a/kspm-jobs/k8tls-job/templates/k8tls-cronjob.yaml
+++ b/kspm-jobs/k8tls-job/templates/k8tls-cronjob.yaml
@@ -64,7 +64,7 @@ spec:
               - name: TENANT_ID
                 value: {{ .Values.tenantID | quote }}
               - name: CLUSTER_NAME
-                value: {{ if ne .Values.clusterName "" }}{{ .Values.clusterName }}{{ else }}{{ "default" }}{{ end }}
+                value: {{ if ne .Values.clusterName "" }}{{ ".Values.global.clusterName" }}{{ else }}{{ "default" }}{{ end }}
               - name: LABEL_NAME
                 value: {{ if ne .Values.label "" }}{{ .Values.label }}{{ else }}{{ "default" }}{{ end }}
             volumeMounts:

--- a/kspm-jobs/k8tls-job/templates/k8tls-job.yaml
+++ b/kspm-jobs/k8tls-job/templates/k8tls-job.yaml
@@ -36,7 +36,7 @@ spec:
           - name: TENANT_ID
             value: {{ .Values.global.tenantID | quote }}
           - name: CLUSTER_NAME
-            value: {{ if ne .Values.global.clusterName "" }}{{ .Values.global.clusterName }}{{ else }}{{ "default" }}{{ end }}
+            value: {{ if ne .Values.global.clusterName "" }}{{ ".Values.global.clusterName" }}{{ else }}{{ "default" }}{{ end }}
           - name: LABEL_NAME
             value: {{ if ne .Values.global.label "" }}{{ .Values.global.label }}{{ else }}{{ "default" }}{{ end }}
         volumeMounts:

--- a/kspm-jobs/kiem-job/templates/cronjob.yaml
+++ b/kspm-jobs/kiem-job/templates/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
               args: ["./kiem", "run", "--mode", "k8s", "--output", "/data/report.json"]
               env:
                 - name: CLUSTER_NAME
-                  value: {{ .Values.global.clusterName }}
+                  value: "{{ .Values.global.clusterName }}"
               volumeMounts:
                 - name: datapath
                   mountPath: /data

--- a/kspm-jobs/kiem-job/templates/job.yaml
+++ b/kspm-jobs/kiem-job/templates/job.yaml
@@ -21,7 +21,7 @@ spec:
           args: ["./kiem", "run", "--mode", "k8s", "--output", "/data/report.json"]
           env:
             - name: CLUSTER_NAME
-              value: {{ .Values.global.clusterName }}
+              value: "{{ .Values.global.clusterName }}"
           volumeMounts:
             - name: datapath
               mountPath: /data


### PR DESCRIPTION
We do a helm install for onboarding the agents. While performing that installation, helm replaces the value.global.clusterName in the templates and stores them in the yaml. While storing them, the templates are written to store without ""(string). 

In this case, since we are passing 2025-10-07 as the format, yaml auto converts it to a string and uses it. Hence this issue is observed. To avoid the issue, we need to add "" to the template reference of clusterName. 