### PR TITLE
fix(jobs): add permission for cis jobs

### DIFF
--- a/kspm-jobs/cis-k8s-job/templates/cis-cron-job.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/cis-cron-job.yaml
@@ -17,9 +17,7 @@ spec:
           imagePullSecrets:
           - name: {{ .Values.registry.secretName | quote }}
           {{- end }}
-          {{- if .Values.global.agents.joinToken }}
           serviceAccount: cis-service-account
-          {{- end }}
           containers:
           - image: "{{ include "cluster_job.image" . }}"
             args: 

--- a/kspm-jobs/cis-k8s-job/templates/cis-job.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/cis-job.yaml
@@ -19,9 +19,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.registry.secretName | quote }}
       {{- end }}
-      {{- if .Values.global.agents.joinToken }}
       serviceAccount: cis-service-account
-      {{- end }}
       containers:
       - image: "{{ include "cluster_job.image" . }}"
         args: 

--- a/kspm-jobs/cis-k8s-job/templates/role.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cis-cluster-role-readonly
+rules:
+- apiGroups: [""]
+  resources:
+    - secrets
+    - serviceaccounts
+    - configmaps
+    - services
+  verbs: ["get", "list"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+    - mutatingwebhookconfigurations
+  verbs: ["get", "list"]
+- apiGroups: ["policy"]
+  resources:
+    - podsecuritypolicies
+  verbs: ["get", "list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+    - "roles"
+    - "rolebindings"
+    - "clusterroles"
+    - "clusterrolebindings"
+  verbs: ["get", "list"]

--- a/kspm-jobs/cis-k8s-job/templates/rolebindings.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/rolebindings.yaml
@@ -13,3 +13,16 @@ roleRef:
   name: {{ printf "spire-cm-secrets-role-%s" .Release.Name }} 
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cis-cluster-role-binding-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cis-cluster-role-readonly
+subjects:
+  - kind: ServiceAccount
+    name: cis-service-account
+    namespace: {{ .Release.Namespace }}

--- a/kspm-jobs/cis-k8s-job/templates/serviceaccount.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/serviceaccount.yaml
@@ -1,7 +1,5 @@
-{{- if .Values.global.agents.joinToken }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cis-service-account
   namespace: {{ .Release.Namespace }}
-{{- end }}


### PR DESCRIPTION
**JIRA:** [CNAPP-22305](https://accu-knox.atlassian.net/browse/CNAPP-22305)

### Context:
For kube-bench scan for `RBAC and Service Accounts` test `5.1.1` the result was always showing failed because the cis job pod didnt have enough permission to get/list service accounts and roles.

**This PR contains the following changes:**
- Add least permissive cluster-role for cis jobs 

[CNAPP-22305]: https://accu-knox.atlassian.net/browse/CNAPP-22305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ