### PR TITLE
chore: Migrate CI workflows to push images and helm charts to Harbor

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -44,19 +44,12 @@ jobs:
           helm lint kspm-runtime
           helm template kspm-runtime --dry-run > /dev/null
 
-  helm_push_to_ecr:
+  helm_push_to_harbor:
     runs-on: ubuntu-latest
     needs: [helm_chart_validation,tag-validate]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Set up AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
 
       - name: Install Helm
         run: |
@@ -64,9 +57,9 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
-      - name: Login to AWS ECR
+      - name: Login to Harbor
         run: |
-          aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin ${{ secrets.REPO }}
+          echo "${{ secrets.HARBOR_PASSWORD }}" | helm registry login harbor.do.accuknox.com --username "${{ secrets.HARBOR_USERNAME }}" --password-stdin
 
       - name: Update Helm Dependencies
         run: |
@@ -83,4 +76,4 @@ jobs:
         run: |
           helm package kspm-runtime
           HELM_PACKAGE=$(ls kspm-runtime-*.tgz)
-          helm push $HELM_PACKAGE oci://${{ secrets.REPO }}
+          helm push $HELM_PACKAGE oci://harbor.do.accuknox.com/kspm

--- a/.github/workflows/push-cx_jobs-image.yaml
+++ b/.github/workflows/push-cx_jobs-image.yaml
@@ -15,20 +15,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to AWS Public ECR
+      - name: Login to Harbor
         run: |
-          aws ecr-public get-login-password --region us-east-1 \
-          | docker login --username AWS --password-stdin public.ecr.aws/k9v9d5v2
+          echo "${{ secrets.HARBOR_PASSWORD }}" | docker login harbor.do.accuknox.com --username "${{ secrets.HARBOR_USERNAME }}" --password-stdin
 
       - name: Determine changed job
         id: detect-folder
@@ -55,5 +48,5 @@ jobs:
           file: ./${{ steps.detect-folder.outputs.job }}/Dockerfile
           push: true
           tags: |
-            public.ecr.aws/k9v9d5v2/${{ steps.detect-folder.outputs.job }}:${{ steps.get-version.outputs.version }}
-            public.ecr.aws/k9v9d5v2/${{ steps.detect-folder.outputs.job }}:latest
+            harbor.do.accuknox.com/jobs/${{ steps.detect-folder.outputs.job }}:${{ steps.get-version.outputs.version }}
+            harbor.do.accuknox.com/jobs/${{ steps.detect-folder.outputs.job }}:latest

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -9,27 +9,18 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to Harbor
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        
-      - name: Set up AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
           
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-
-      - name: Login to AWS ECR
+      - name: Login to Harbor
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/k9v9d5v2
-    
+          echo "${{ secrets.HARBOR_PASSWORD }}" | docker login harbor.do.accuknox.com --username "${{ secrets.HARBOR_USERNAME }}" --password-stdin
          
       - name: Determine version
         id: vars
@@ -50,4 +41,4 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: public.ecr.aws/k9v9d5v2/cluster-job:${{ steps.vars.outputs.tag }}
+          tags: harbor.do.accuknox.com/jobs/cluster-job:${{ steps.vars.outputs.tag }}

--- a/kspm-jobs/cis-k8s-job/values.yaml
+++ b/kspm-jobs/cis-k8s-job/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 cluster_job:
-  owner: public.ecr.aws/k9v9d5v2
+  owner: harbor.do.accuknox.com/jobs
   repository: knoxjobs
   tag: "v0.1.4"
   image: ""

--- a/kspm-jobs/k8s-risk-assessment-job/values.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 cluster_job:
-  owner: public.ecr.aws/k9v9d5v2
+  owner: harbor.do.accuknox.com/jobs
   repository: knoxjobs
   tag: "v0.1.4"
   image: ""

--- a/kspm-jobs/k8tls-job/values.yaml
+++ b/kspm-jobs/k8tls-job/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 cluster_job:
-  owner: public.ecr.aws/k9v9d5v2
+  owner: harbor.do.accuknox.com/jobs
   repository: cluster-job
   tag: "latest"
   image: ""

--- a/kspm-jobs/kiem-job/values.yaml
+++ b/kspm-jobs/kiem-job/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 cluster_job:
-  owner: public.ecr.aws/k9v9d5v2
+  owner: harbor.do.accuknox.com/jobs
   repository: knoxjobs
   tag: "v0.1.4"
   image: ""

--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -10,7 +10,7 @@ appVersion: "0.1.0"
 dependencies:
   - name: agents-chart
     version: "v0.11.14"
-    repository: oci://public.ecr.aws/k9v9d5v2  
+    repository: oci://harbor.do.accuknox.com/agents/accuknox  
     condition: global.agents.enabled
   - name: kubearmor-operator
     version: v1.6.6
@@ -28,9 +28,9 @@ dependencies:
     version: "0.1.0"
     repository: "file://../kspm-jobs/kiem-job"
     condition: global.kiem.enabled     
-  - name: knoxguard-chart
+  - name: knoxguard
     version: v0.2.1
-    repository: oci://public.ecr.aws/k9v9d5v2
+    repository: oci://harbor.do.accuknox.com/accuknox/helm-chart
     condition: admissionController.enabled
   - name: kyverno
     version: 3.3.7
@@ -38,5 +38,5 @@ dependencies:
     condition: kyverno.enabled
   - name: kubeshield-chart
     version: v0.2.8
-    repository: oci://public.ecr.aws/k9v9d5v2
+    repository: oci://harbor.do.accuknox.com/kubeshield/kubeshield-chart
     condition: global.inClusterScan.enabled


### PR DESCRIPTION
### What changed
- Updated workflows to push artifacts to Harbor instead of public ECR

### Required secrets
Before merging we need to be ensure the GitHub secrets are configured that are uses in the workflow
- `HARBOR_USERNAME`
- `HARBOR_PASSWORD`
