### PR TITLE
Helm uninstall fix

### DIFF
--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -33,8 +33,8 @@ dependencies:
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: admissionController.enabled
   - name: kyverno
-    version: 3.6.2
-    repository: https://kyverno.github.io/kyverno/
+    version: v1.16.2
+    repository: oci://public.ecr.aws/k9v9d5v2
     condition: kyverno.enabled
   - name: kubeshield-chart
     version: v0.3.0-patch

--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -33,8 +33,8 @@ dependencies:
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: admissionController.enabled
   - name: kyverno
-    version: 3.6.2
-    repository: https://kyverno.github.io/kyverno/
+    version: v3.6.2
+    repository: oci://public.ecr.aws/k9v9d5v2
     condition: kyverno.enabled
   - name: kubeshield-chart
     version: v0.3.0-patch

--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -33,10 +33,10 @@ dependencies:
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: admissionController.enabled
   - name: kyverno
-    version: 3.3.7
+    version: 3.6.2
     repository: https://kyverno.github.io/kyverno/
     condition: kyverno.enabled
   - name: kubeshield-chart
-    version: v0.3.0
+    version: v0.3.0-patch
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: global.inClusterScan.enabled

--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     condition: admissionController.enabled
   - name: kyverno
     version: 3.6.2
-    repository: oci://public.ecr.aws/k9v9d5v2
+    repository: https://kyverno.github.io/kyverno/
     condition: kyverno.enabled
   - name: kubeshield-chart
     version: v0.3.0-patch

--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: admissionController.enabled
   - name: kyverno
-    version: v3.6.2
+    version: 3.6.2
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: kyverno.enabled
   - name: kubeshield-chart

--- a/kspm-runtime/templates/cleanup-job.yaml
+++ b/kspm-runtime/templates/cleanup-job.yaml
@@ -132,8 +132,8 @@ spec:
             kubearmor-snitch-binding
           
           # Delete release namespace
-          echo "Deleting {{ .Release.Namespace }} namespace..."
-          kubectl delete ns {{ .Release.Namespace }} --ignore-not-found=true
+          #echo "Deleting {{ .Release.Namespace }} namespace..."
+          #kubectl delete ns {{ .Release.Namespace }} --ignore-not-found=true
           
           echo "Cleanup completed successfully!"
 {{- end }}

--- a/kspm-runtime/values.yaml
+++ b/kspm-runtime/values.yaml
@@ -121,6 +121,8 @@ admissionController:
 
 kyverno:
   enabled: false
+  webhooksCleanup:
+    enabled: false
 
 # Cleanup configuration for helm uninstall
 # Uses restricted RBAC with resourceNames for security (least privilege)


### PR DESCRIPTION
Fix the **kyverno ImagePullBackOff** issue while uninstalling the agents. 
Created a private repo for Kyverno and the kyverno chart is now pulled from our ECR registry.