### PR TITLE
fix(spire): change helper name from main chart

### DIFF
--- a/kspm-runtime/templates/_helpers.tpl
+++ b/kspm-runtime/templates/_helpers.tpl
@@ -29,9 +29,9 @@ Return the chart version.
 {{- end -}}
 
 {{/*
-Helper to check if Spire is enabled.
+Helper to check if Spire roles needs to be enabled.
 */}}
-{{- define "spire.enabled" -}}
+{{- define "spire.roles.enabled" -}}
   {{- if and (or (ne .Values.global.agents.joinToken "") (ne .Values.global.agents.accessKey "")) (eq .Values.global.authToken "") -}}
     true
   {{- else -}}

--- a/kspm-runtime/templates/roles.yaml
+++ b/kspm-runtime/templates/roles.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "spire.enabled" . ) "true" }}  
+{{- if eq (include "spire.roles.enabled" . ) "true" }}  
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
With the updated jobs container we have the ability to connect to spire agent if agents or incluster scan is enabled. The helper function that disables spire deployment `spire.enabled` is defined in the parent chart as well as the child chart due to this the child chart gets its value replaced by the parent function. 
- This change is introduced to change the parent chart function name 