### PR TITLE
fix(agents): upgrade agent version to v0.11.25

### DIFF
--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -9,7 +9,7 @@ appVersion: "0.1.0"
 
 dependencies:
   - name: agents-chart
-    version: "v0.11.24"
+    version: "v0.11.25"
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: global.agents.enabled
   - name: kubearmor-operator

--- a/kspm-runtime/values.yaml
+++ b/kspm-runtime/values.yaml
@@ -77,6 +77,8 @@ global:
     joinToken: ""
     clusterName: ""
     tokenURL: ""
+    feeder:
+      gatekeeper: false
 
   spireHost: ""
   spirePort: 8081


### PR DESCRIPTION
This PR contains the following changes:
- update agents-chart version to v0.11.25 
  - update local registry agent to support http based registries
  - disable connecting to gatekeeper by default in feeder-service
- new flag to enable gatekeeper service in feeder-service  