### PR TITLE
feat: add nodeSelector and tolerations support to kspm-jobs charts

### DIFF
--- a/kspm-jobs/cis-k8s-job/templates/cis-cron-job.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/cis-cron-job.yaml
@@ -20,6 +20,14 @@ spec:
           imagePullSecrets:
           - name: {{ .Values.global.registry.secretName }}-cis
           {{- end }}
+          {{- if .Values.global.nodeSelector }}
+          nodeSelector:
+            {{- toYaml .Values.global.nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if .Values.global.tolerations }}
+          tolerations:
+            {{- toYaml .Values.global.tolerations | nindent 12 }}
+          {{- end }}
           serviceAccount: cis-service-account
           containers:
           - image: "{{ include "cluster_job.image" . }}"

--- a/kspm-jobs/cis-k8s-job/templates/cis-job.yaml
+++ b/kspm-jobs/cis-k8s-job/templates/cis-job.yaml
@@ -20,6 +20,14 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.registry.secretName }}-cis
       {{- end }}
+      {{- if .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      {{- end }}
       serviceAccount: cis-service-account
       containers:
       - image: "{{ include "cluster_job.image" . }}"

--- a/kspm-jobs/cis-k8s-job/values.yaml
+++ b/kspm-jobs/cis-k8s-job/values.yaml
@@ -42,8 +42,11 @@ global:
   certURL: ""  # Set this for cert URL if needed (if certPath is set as well certPath will take precedent)
   skipTLSVerification: false  # Set to true if insecure connection is needed
 
+  nodeSelector: {} # Node selector for scheduling the job --set nodeSelector."kubernetes.io/os"=linux
+  tolerations: [] # Tolerations for scheduling pods on tainted nodes e.g. --set global.tolerations[0].key=dedicated --set global.tolerations[0].operator=Equal --set global.tolerations[0].value=accuknox --set global.tolerations[0].effect=NoSchedule
+
   # To use existing secret updated {global.registry.secretName} with your secret name.
-  registry: 
+  registry:
     url: ""
     secretName: ""
     username: ""

--- a/kspm-jobs/k8s-risk-assessment-job/templates/cronjob.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/cronjob.yaml
@@ -21,7 +21,15 @@ spec:
         {{- if .Values.global.registry.secretName }}
           imagePullSecrets:
           - name: {{ .Values.global.registry.secretName }}-k8s
-        {{- end }}        
+        {{- end }}
+          {{- if .Values.global.nodeSelector }}
+          nodeSelector:
+            {{- toYaml .Values.global.nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if .Values.global.tolerations }}
+          tolerations:
+            {{- toYaml .Values.global.tolerations | nindent 12 }}
+          {{- end }}
           initContainers:
             - name: job-init-container
               image: "{{ include "kubescape.image" . }}"

--- a/kspm-jobs/k8s-risk-assessment-job/templates/job.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/job.yaml
@@ -15,7 +15,15 @@ spec:
     {{- if .Values.global.registry.secretName }}
       imagePullSecrets:
       - name: {{ .Values.global.registry.secretName }}-k8s
-    {{- end }}     
+    {{- end }}
+      {{- if .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: job-init-container
           image: "{{ include "kubescape.image" . }}"

--- a/kspm-jobs/k8s-risk-assessment-job/values.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/values.yaml
@@ -37,8 +37,11 @@ global:
   certURL: ""  # Set this for cert URL if needed (if certPath is set as well certPath will take precedent)
   skipTLSVerification: false  # Set to true if insecure connection is needed
 
+  nodeSelector: {} # Node selector for scheduling the job --set nodeSelector."kubernetes.io/os"=linux
+  tolerations: [] # Tolerations for scheduling pods on tainted nodes e.g. --set global.tolerations[0].key=dedicated --set global.tolerations[0].operator=Equal --set global.tolerations[0].value=accuknox --set global.tolerations[0].effect=NoSchedule
+
   # To use existing secret updated {global.registry.secretName} with your secret name.
-  registry: 
+  registry:
     url: ""
     secretName: ""
     username: ""

--- a/kspm-jobs/kiem-job/templates/cronjob.yaml
+++ b/kspm-jobs/kiem-job/templates/cronjob.yaml
@@ -20,7 +20,15 @@ spec:
         {{- if .Values.global.registry.secretName }}
           imagePullSecrets:
           - name: {{ .Values.global.registry.secretName }}-kiem
-        {{- end }}         
+        {{- end }}
+          {{- if .Values.global.nodeSelector }}
+          nodeSelector:
+            {{- toYaml .Values.global.nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if .Values.global.tolerations }}
+          tolerations:
+            {{- toYaml .Values.global.tolerations | nindent 12 }}
+          {{- end }}
           initContainers:
             - name: kiem-init
               image: "{{ include "kiem.image" . }}"

--- a/kspm-jobs/kiem-job/templates/job.yaml
+++ b/kspm-jobs/kiem-job/templates/job.yaml
@@ -15,7 +15,15 @@ spec:
     {{- if .Values.global.registry.secretName }}
       imagePullSecrets:
       - name: {{ .Values.global.registry.secretName }}-kiem
-    {{- end }}      
+    {{- end }}
+      {{- if .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: kiem-init
           image: "{{ include "kiem.image" . }}"

--- a/kspm-jobs/kiem-job/values.yaml
+++ b/kspm-jobs/kiem-job/values.yaml
@@ -35,8 +35,11 @@ global:
   certURL: ""  # Set this for cert URL if needed (if certPath is set as well certPath will take precedent)
   skipTLSVerification: false  # Set to true if insecure connection is needed
 
+  nodeSelector: {} # Node selector for scheduling the job --set nodeSelector."kubernetes.io/os"=linux
+  tolerations: [] # Tolerations for scheduling pods on tainted nodes e.g. --set global.tolerations[0].key=dedicated --set global.tolerations[0].operator=Equal --set global.tolerations[0].value=accuknox --set global.tolerations[0].effect=NoSchedule
+
   # To use existing secret updated {global.registry.secretName} with your secret name.
-  registry: 
+  registry:
     url: ""
     secretName: ""
     username: ""

--- a/kspm-runtime/values.yaml
+++ b/kspm-runtime/values.yaml
@@ -112,6 +112,8 @@ global:
     enabled: false
   inClusterScan:
     enabled: false
+  nodeSelector: {} # Node selector for scheduling the job --set nodeSelector."kubernetes.io/os"=linux
+  tolerations: [] # Tolerations for scheduling pods on tainted nodes e.g. --set global.tolerations[0].key=dedicated --set global.tolerations[0].operator=Equal --set global.tolerations[0].value=accuknox --set global.tolerations[0].effect=NoSchedule
 
 # Values specific to KubeArmorOperator sub-chart
 kubearmor-operator:


### PR DESCRIPTION
## Summary

- Added `global.nodeSelector` and `global.tolerations` fields to `values.yaml` in `cis-k8s-job`, `k8s-risk-assessment-job`, and `kiem-job` charts
- Updated `job.yaml` and `cronjob.yaml` templates in all 3 charts to render `nodeSelector` and `tolerations` when set
- Both fields are optional and default to empty — no impact on existing deployments

## Changes

| Chart | Files Changed |
|---|---|
| `cis-k8s-job` | `values.yaml`, `templates/cis-job.yaml`, `templates/cis-cron-job.yaml` |
| `k8s-risk-assessment-job` | `values.yaml`, `templates/job.yaml`, `templates/cronjob.yaml` |
| `kiem-job` | `values.yaml`, `templates/job.yaml`, `templates/cronjob.yaml` |

## Usage

```bash
# Schedule pods on specific nodes
--set global.nodeSelector."kubernetes\.io/os"=linux

# Tolerate tainted nodes
--set global.tolerations[0].key=dedicated \
--set global.tolerations[0].operator=Equal \
--set global.tolerations[0].value=accuknox \
--set global.tolerations[0].effect=NoSchedule
```

