### PR TITLE
fix(vuln): upgrade jobs pod and agents version

### DIFF
--- a/kspm-jobs/cis-k8s-job/values.yaml
+++ b/kspm-jobs/cis-k8s-job/values.yaml
@@ -5,7 +5,7 @@
 cluster_job:
   owner: harbor.do.accuknox.com/accuknox-ecr/k9v9d5v2
   repository: knoxjobs
-  tag: "v0.1.7"
+  tag: "v0.1.8"
   image: ""
 
 kubeBench:

--- a/kspm-jobs/k8s-risk-assessment-job/values.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/values.yaml
@@ -5,7 +5,7 @@
 cluster_job:
   owner: harbor.do.accuknox.com/accuknox-ecr/k9v9d5v2
   repository: knoxjobs
-  tag: "v0.1.7"
+  tag: "v0.1.8"
   image: ""
 
 kubescape:

--- a/kspm-jobs/kiem-job/values.yaml
+++ b/kspm-jobs/kiem-job/values.yaml
@@ -5,7 +5,7 @@
 cluster_job:
   owner: harbor.do.accuknox.com/accuknox-ecr/k9v9d5v2
   repository: knoxjobs
-  tag: "v0.1.7"
+  tag: "v0.1.8"
   image: ""
   
 kiem:


### PR DESCRIPTION
This PR contains the following changes:
- upgrade knox-jobs container to vulnerable free image
- upgrade agents version

Dependent PR 
- https://github.com/accuknox/agents-chart/pull/476