### PR TITLE
fix(clusterName): allow passing numbers as cluster name

### DIFF
--- a/kspm-jobs/cis-k8s-job/templates/_helpers.tpl
+++ b/kspm-jobs/cis-k8s-job/templates/_helpers.tpl
@@ -410,13 +410,7 @@ Return access key URL:
 Return cluster name for spire access keys
 */}}
 {{- define "jobs.clusterName" -}}
-{{- if  ne .Values.global.clusterName "" -}}
-    {{- .Values.global.clusterName -}}
-{{- else if ne .Values.global.agents.clusterName "" -}}
-    {{- .Values.global.agents.clusterName -}}
-{{- else -}}
-    ""
-{{- end -}}
+{{- coalesce .Values.global.clusterName .Values.global.agents.clusterName -}}
 {{- end -}}
 
 

--- a/kspm-jobs/k8s-risk-assessment-job/templates/_helpers.tpl
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/_helpers.tpl
@@ -177,13 +177,7 @@ Return access key URL:
 Return cluster name for spire access keys
 */}}
 {{- define "jobs.clusterName" -}}
-{{- if  ne .Values.global.clusterName "" -}}
-    {{- .Values.global.clusterName -}}
-{{- else if ne .Values.global.agents.clusterName "" -}}
-    {{- .Values.global.agents.clusterName -}}
-{{- else -}}
-    ""
-{{- end -}}
+{{- coalesce .Values.global.clusterName .Values.global.agents.clusterName -}}
 {{- end -}}
 
 

--- a/kspm-jobs/kiem-job/templates/_helpers.tpl
+++ b/kspm-jobs/kiem-job/templates/_helpers.tpl
@@ -243,13 +243,7 @@ Return access key URL:
 Return cluster name for jobs pod
 */}}
 {{- define "jobs.clusterName" -}}
-{{- if  ne .Values.global.clusterName "" -}}
-    {{- .Values.global.clusterName -}}
-{{- else if ne .Values.global.agents.clusterName "" -}}
-    {{- .Values.global.agents.clusterName -}}
-{{- else -}}
-    ""
-{{- end -}}
+{{- coalesce .Values.global.clusterName .Values.global.agents.clusterName -}}
 {{- end -}}
 
 


### PR DESCRIPTION
JIRA: https://accu-knox.atlassian.net/browse/CNAPP-26413

This PR contains the following changes:
- Simplify `jobs.clusterName` Helm template logic
- Replace conditional checks with `coalesce` for safer value resolution

**Testing:**
- Verified with the following scenarios 
  - `--set global.clusterName=""`
  - `--set global.clusterName="123"`
  - `--set global.clusterName=123`
  - `--set global.clusterName=0` 
  - `--set global.agents.clusterName=""`
  - `--set global.agents.clusterName="123"`
  - `--set global.agents.clusterName=123`
  - `--set global.agents.clusterName=0`