### PR TITLE
chore(kspm): Upgrade kubeshield chart version to v0.4.0

### DIFF
--- a/kspm-runtime/Chart.yaml
+++ b/kspm-runtime/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: kyverno.enabled
   - name: kubeshield-chart
-    version: v0.3.9
+    version: v0.4.0
     repository: oci://public.ecr.aws/k9v9d5v2
     condition: global.inClusterScan.enabled


### PR DESCRIPTION
**Purpose of this PR?**

- Upgraded kubeshield version to v0.4.0 to include CRI-O changes.
- Removed port from the spire server address.
