### PR TITLE
CNAPP-27594 Exlude openshift-ovn-k8s ns to ignore kubescape error

### DIFF
--- a/kspm-jobs/cis-k8s-job/values.yaml
+++ b/kspm-jobs/cis-k8s-job/values.yaml
@@ -6,7 +6,7 @@ registryName: public.ecr.aws/k9v9d5v2
 
 cluster_job:
   repository: knoxjobs
-  tag: "v0.1.9"
+  tag: "v0.1.10"
   image: ""
 
 kubeBench:

--- a/kspm-jobs/k8s-risk-assessment-job/Dockerfile
+++ b/kspm-jobs/k8s-risk-assessment-job/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.23 AS downloader
 RUN apk add --no-cache ca-certificates curl
-ENV KUBESCAPE_VERSION=4.0.3
+ENV KUBESCAPE_VERSION=4.0.10
 ARG ARCH=""
 RUN curl \
     -L "https://github.com/kubescape/kubescape/releases/download/v${KUBESCAPE_VERSION}/kubescape_${KUBESCAPE_VERSION}_linux_${ARCH}" \

--- a/kspm-jobs/k8s-risk-assessment-job/templates/cronjob.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/cronjob.yaml
@@ -39,6 +39,7 @@ spec:
                 - >
                   wget -O /tmp/controls.json '{{ .Values.global.kraCustomConfig }}' &&
                   kubescape scan framework
+                  --exclude-namespaces openshift-ovn-kubernetes
                   --format json
                   --cache-dir /data/kubescape-cache
                   --output /data/report.json
@@ -53,6 +54,8 @@ spec:
                 - scan
                 - framework
                 - allcontrols,clusterscan,mitre,nsa
+                - --exclude-namespaces
+                - openshift-ovn-kubernetes
                 - --format
                 - json
                 - --cache-dir

--- a/kspm-jobs/k8s-risk-assessment-job/templates/job.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/templates/job.yaml
@@ -33,6 +33,7 @@ spec:
             - >
               wget -O /tmp/controls.json '{{ .Values.global.kraCustomConfig }}' &&
               kubescape scan framework allcontrols,clusterscan,mitre,nsa
+              --exclude-namespaces openshift-ovn-kubernetes
               --format json
               --cache-dir /data/kubescape-cache
               --output /data/report.json
@@ -47,6 +48,8 @@ spec:
             - scan
             - framework
             - allcontrols,clusterscan,mitre,nsa
+            - --exclude-namespaces
+            - openshift-ovn-kubernetes
             - --format
             - json
             - --cache-dir

--- a/kspm-jobs/k8s-risk-assessment-job/values.yaml
+++ b/kspm-jobs/k8s-risk-assessment-job/values.yaml
@@ -6,7 +6,7 @@ registryName: public.ecr.aws/k9v9d5v2
 
 cluster_job:
   repository: knoxjobs
-  tag: "v0.1.9"
+  tag: "v0.1.10"
   image: ""
 
 kubescape:

--- a/kspm-jobs/kiem-job/values.yaml
+++ b/kspm-jobs/kiem-job/values.yaml
@@ -6,7 +6,7 @@ registryName: public.ecr.aws/k9v9d5v2
 
 cluster_job:
   repository: knoxjobs
-  tag: "v0.1.9"
+  tag: "v0.1.10"
   image: ""
   
 kiem:


### PR DESCRIPTION
To fix the vulnerabilities present in kubescape, we upgraded to latest version of kubescape(v4.0.10).

The latest version of kubescape runs an overview scan instead of running scan for specific controls. 
This overview scan, runs scan also for node. Ideally the node scan requires node-agent to be present/installed as part of the cluster. This installation is possible only through kubescape-operator. 

The kubescape refers to the control under the downloaded artifact. We need to remove this control from the allcontrols/clusterscan which is quite tricky. 

To surpass the below error, we are ignoring the openshift-ovn-k8s ns. 

`{"level":"fatal","ts":"2026-07-14T11:43:30Z","msg":"control \"C-0048\": rule \"alert-any-hostpath\": rego eval failed for namespace \"openshift-ovn-kubernetes\": rule 'alert-any-hostpath': rego eval failed: alert-any-hostpath:87: eval_conflict_error: functions must not produce multiple outputs for same inputs"}
`